### PR TITLE
Add enemy counts to CardModifier

### DIFF
--- a/entities/player/player.gd
+++ b/entities/player/player.gd
@@ -17,8 +17,9 @@ func _ready() -> void:
 	
 ## Updates player stats based on selected card and emits
 ## player_stats_updated signal
-func _on_card_selected(card_mods: Array[StatModifier]) -> void:
-	for stat_mod in card_mods:
+func _on_card_selected(card: CardModifier) -> void:
+	
+	for stat_mod in card.modifiers:
 		stats.update_stat(stat_mod, tempStatManager)
 	
 	EventManager.emit_signal("player_stats_updated", stats)

--- a/items/shield_item_1.tres
+++ b/items/shield_item_1.tres
@@ -6,8 +6,8 @@
 [resource]
 script = ExtResource("1_dmtfs")
 texture = ExtResource("2_po2e0")
-target = 0
-value = 0
+target = 2
+value = 1
 type = 0
 duration = 0.0
 metadata/_custom_type_script = "uid://cw0vu353hkrdw"

--- a/items/weak_weapon.tres
+++ b/items/weak_weapon.tres
@@ -6,8 +6,8 @@
 [resource]
 script = ExtResource("1_opapl")
 texture = ExtResource("2_opapl")
-target = 0
-value = 0
+target = 1
+value = 1
 type = 0
 duration = 0.0
 metadata/_custom_type_script = "uid://cw0vu353hkrdw"

--- a/scripts/EventManager.gd
+++ b/scripts/EventManager.gd
@@ -2,7 +2,7 @@ extends Node
 
 signal level_passed(new_level: int)
 
-signal card_selected(card: Array[StatModifier])
+signal card_selected(card: CardModifier)
 
 signal player_stats_updated(new_stats: CharacterStats)
 signal player_stat_modified(_statmod: StatModifier)

--- a/scripts/cards/card_modifier.gd
+++ b/scripts/cards/card_modifier.gd
@@ -2,3 +2,7 @@ class_name CardModifier
 
 var modifiers: Array[StatModifier] = []
 var duration_floors: int
+
+#region Debuffs
+var enemy_count
+#endregion

--- a/scripts/stats/character_stats.gd
+++ b/scripts/stats/character_stats.gd
@@ -29,24 +29,24 @@ func _init() -> void:
 		speed._init()
 
 ## Deprecated. Use update_stat
-func add_temp_stat(stats_mod: StatModifier, player_state_manager: TempStatManager) -> void:
-	match stats_mod.target:
-		Type.HEALTH:
-			if health != null:
-				health.add_temp_stat_modifier(stats_mod, player_state_manager)
-				print("Health modified")
-		Type.STRENGTH:
-			if strength != null:
-				strength.add_temp_stat_modifier(stats_mod, player_state_manager)
-				print("Strength modified")
-		Type.DEFENSE:
-			if defense != null:
-				defense.add_temp_stat_modifier(stats_mod, player_state_manager)
-				print("Defense modified")
-		Type.SPEED:
-			if speed != null:
-				speed.add_temp_stat_modifier(stats_mod, player_state_manager)
-				print("Speed modified")
+#func add_temp_stat(stats_mod: StatModifier, player_state_manager: TempStatManager) -> void:
+	#match stats_mod.target:
+		#Type.HEALTH:
+			#if health != null:
+				#health.add_temp_stat_modifier(stats_mod, player_state_manager)
+				#print("Health modified")
+		#Type.STRENGTH:
+			#if strength != null:
+				#strength.add_temp_stat_modifier(stats_mod, player_state_manager)
+				#print("Strength modified")
+		#Type.DEFENSE:
+			#if defense != null:
+				#defense.add_temp_stat_modifier(stats_mod, player_state_manager)
+				#print("Defense modified")
+		#Type.SPEED:
+			#if speed != null:
+				#speed.add_temp_stat_modifier(stats_mod, player_state_manager)
+				#print("Speed modified")
 
 func update_stat(stats_mod: StatModifier, player_state_manager: TempStatManager) -> void:
 	var stat_type: Stat


### PR DESCRIPTION
Adds an `enemy_count` attribute to the `CardModifier`. This allows functions to access StatModifiers or additional information. 

Set up the world to also read the selected card so it can update the difficulty based on this `enemy_count`.

Any new attributes could be added `CardModifier` and the world could read them. The difficult part would be decided what buffs to give to the card.